### PR TITLE
Setup jsonlint tests and configuration for TravisCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
+# dependencies
+node_modules
+
+# Only apps should have lockfiles
+yarn.lock
+package-lock.json
+
+# misc
+npm-debug.log*
+yarn-error.log
+
+# OS generated files
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+---
+language: node_js
+node_js:
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "4"
+
+sudo: false
+dist: trusty
+
+cache:
+  directories:
+    - $HOME/.npm
+
+before_install:
+  - npm config set spin false

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ update:
 	node scripts/importer $(REGISTRY_CACHE) data/json
 
 test:
-	jshint data/json/*.json
+	find ./data/json/*.json -exec ./node_modules/.bin/jsonlint -q {} \;
 
 .PHONY: update test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
 	"name": "language-subtag-registry",
 	"version": "0.3.18",
-	"implements": ["CommonJS/Modules/1.0"],
+	"implements": [
+		"CommonJS/Modules/1.0"
+	],
 	"description": "Full BCP 47 language subtag data from the official IANA repository, in JSON format with multiple indices.",
 	"homepage": "https://github.com/mattcg/language-subtag-registry",
 	"repository": {
@@ -12,6 +14,10 @@
 		{
 			"name": "Matthew Caruana Galizia",
 			"email": "m@m.cg"
+		},
+		{
+			"name": "Guillaume Gérard",
+			"email": "guillaume.gerard88@gmail.com"
 		}
 	],
 	"licenses": [
@@ -29,5 +35,8 @@
 		"subtags",
 		"rfc5646",
 		"language"
-	]
+	],
+	"devDependencies": {
+		"jsonlint": "1.x.x"
+	}
 }


### PR DESCRIPTION
I change jshint to jsonlint. jshint is not working for JSON file.
A small trick about jsonlint, the tool is not able to take a list of file so I use the find command to fix it.

And I add a TravisCI configuration to enable tests for free, see the log for this PR: https://travis-ci.org/GreatWizard/language-subtag-registry/builds/354695449 :)

